### PR TITLE
Update docs page so the Zombies info API url copied instead of Areas

### DIFF
--- a/pages/docs.tsx
+++ b/pages/docs.tsx
@@ -352,7 +352,7 @@ const Docs: NextPage = () => {
               </div>
               <div className="bg-gray-200">
                 <CopyToClipboard
-                  text="https://pvz-2-api.vercel.app/api/areas/[zombie_name]"
+                  text="https://pvz-2-api.vercel.app/api/zombies/[zombie_name]"
                   onCopy={(e) => {
                     notify();
                   }}


### PR DESCRIPTION
FIXES #39 